### PR TITLE
forward Solr to a non-default port #5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -117,7 +117,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.network "private_network", type: "dhcp"
     config.vm.network "forwarded_port", guest: 80, host: 8888
     config.vm.network "forwarded_port", guest: 443, host: 9999
-    config.vm.network "forwarded_port", guest: 8983, host: 8983
+    config.vm.network "forwarded_port", guest: 8983, host: 8993
     config.vm.network "forwarded_port", guest: 8080, host: 8088
     config.vm.network "forwarded_port", guest: 8181, host: 8188
 


### PR DESCRIPTION
This is how I would fix #5 but if another port is preferred, that's fine. With this fix in place I was able to spin up puppetized Dataverse! https://github.com/IQSS/dataverse-puppet/issues/3#issuecomment-144754190 :)
